### PR TITLE
Support for Options of a nullable type

### DIFF
--- a/Jarilo.Tests/OptionsTests/Nullable/Asserts.cs
+++ b/Jarilo.Tests/OptionsTests/Nullable/Asserts.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Jarilo.Tests.OptionsTests.Nullable
+{
+    static class Asserts
+    {
+        public static string[] AssertOption(this string[] output, int? expectedValue)
+        {
+            Assert.Equal(1, output.Length);
+            Assert.Equal(Command.Message(expectedValue), output[0]);
+            return output;
+        }
+    }
+}

--- a/Jarilo.Tests/OptionsTests/Nullable/Command.cs
+++ b/Jarilo.Tests/OptionsTests/Nullable/Command.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Jarilo.Tests.OptionsTests.Nullable
+{
+    [Command("options-tests nullable", "Command for testing nullable type option.")]
+    class Command
+    {
+        public static string Name => "options-tests nullable";
+
+        public static string Message(int? value)
+            => $"nullable option: {value}";
+
+        public void Run(Options options)
+        {
+            Console.WriteLine(Message(options.Nullable));
+        }
+    }
+}

--- a/Jarilo.Tests/OptionsTests/Nullable/Options.cs
+++ b/Jarilo.Tests/OptionsTests/Nullable/Options.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Jarilo.Tests.OptionsTests.Nullable
+{
+    class Options
+    {
+        [Option("--nullable", "Nullable option.")]
+        public int? Nullable { get; set; }
+    }
+}

--- a/Jarilo.Tests/OptionsTests/Nullable/Tests.cs
+++ b/Jarilo.Tests/OptionsTests/Nullable/Tests.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Jarilo.Tests.OptionsTests.Nullable
+{
+    public class Tests
+    {
+        [Fact]
+        public async Task NoOption_DefaultValue()
+        {
+            var args = Command.Name;
+            await AppTest.Run(args, output =>
+            {
+                output.AssertOption(null);
+            });
+        }
+
+        [Fact]
+        public async Task DotSeparator_Success()
+        {
+            var args = $"{Command.Name} --nullable 47";
+            await AppTest.Run(args, output =>
+            {
+                output.AssertOption(47);
+            });
+        }
+
+        [Fact]
+        public async Task CommaSeparator_Success()
+        {
+            var args = $"{Command.Name} --nullable 47";
+            await AppTest.Run(args, output =>
+            {
+                output.AssertOption(47);
+            });
+        }
+
+        [Fact]
+        public async Task Many_FirstInteger_OnlyFirstRead()
+        {
+            var args = $"{Command.Name} --nullable 47 any values 1 2 3";
+            await AppTest.Run(args, output =>
+            {
+                output.AssertOption(47);
+            });
+        }
+
+        [Fact]
+        public async Task Many_FirstNotInteger_ThrowsException()
+        {
+            var args = $"{Command.Name} --nullable not-integer 47 any values 1 2 3";
+            await AppTest.Run(args, output =>
+            {
+                output.AssertParsingException("--nullable", "not-integer");
+            });
+        }
+    }
+}

--- a/Jarilo.Tests/OptionsTests/Nullable/Tests.cs
+++ b/Jarilo.Tests/OptionsTests/Nullable/Tests.cs
@@ -19,17 +19,7 @@ namespace Jarilo.Tests.OptionsTests.Nullable
         }
 
         [Fact]
-        public async Task DotSeparator_Success()
-        {
-            var args = $"{Command.Name} --nullable 47";
-            await AppTest.Run(args, output =>
-            {
-                output.AssertOption(47);
-            });
-        }
-
-        [Fact]
-        public async Task CommaSeparator_Success()
+        public async Task NormalUse_Success()
         {
             var args = $"{Command.Name} --nullable 47";
             await AppTest.Run(args, output =>

--- a/Jarilo/Metadata/Builders/ValueMetadataBuilder.cs
+++ b/Jarilo/Metadata/Builders/ValueMetadataBuilder.cs
@@ -13,6 +13,7 @@ namespace Jarilo.Metadata.Builders
             var propertyCoreType = property.PropertyType.IsArray
                 ? property.PropertyType.GetElementType()
                 : property.PropertyType;
+            propertyCoreType = Nullable.GetUnderlyingType(propertyCoreType) ?? propertyCoreType;
             if (!propertyCoreType.IsEnum)
             {
                 return null;

--- a/Jarilo/Parsing/PropertyValueParser.cs
+++ b/Jarilo/Parsing/PropertyValueParser.cs
@@ -50,6 +50,11 @@ namespace Jarilo.Parsing
             {
                 return ParseEnum(propertyType, value);
             }
+            else if (IsNullable(propertyType))
+            {
+                string[] valueAsArray = new string[] { value };
+                return ParseValue(Nullable.GetUnderlyingType(propertyType), ref valueAsArray);
+            }
             try
             {
                 return Convert.ChangeType(value, propertyType, CultureInfo.InvariantCulture);
@@ -81,5 +86,8 @@ namespace Jarilo.Parsing
                 return optionEnumValueAggregate.EnumValue;
             }
         }
+
+        private static bool IsNullable(Type type) => Nullable.GetUnderlyingType(type) != null;
+
     }
 }


### PR DESCRIPTION
Hello, Nice project.  Thanks for offering it.
I wanted to be able to have options that are nullable, e.g.:
```cs
	class Arguments
	{
		[Option("--integer", "An integer")]
		public int? Integer { get; set; }
	}
```