### PR TITLE
Null value description will not show a dash in help

### DIFF
--- a/Jarilo.Tests/HelpTests/Asserts.cs
+++ b/Jarilo.Tests/HelpTests/Asserts.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Jarilo.Tests.HelpTests.Enum
+{
+    static class Asserts
+    {
+        public static void AssertText(this string[] output, int index, string expectedValue)
+        {
+            Assert.Equal(expectedValue, output[index].TrimStart());
+        }
+    }
+}

--- a/Jarilo.Tests/HelpTests/Command.cs
+++ b/Jarilo.Tests/HelpTests/Command.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Jarilo.Tests.HelpTests.Enum
+{
+    [Command("help-tests enum", "Command for testing help of an enum.")]
+    class Command
+    {
+        public static string Name => "help-tests enum";
+
+        public static string Message(string value)
+            => $"enum option: {value}";
+
+        public void Run(Options options)
+        {
+            Console.WriteLine(Message(options.Enum.ToString()));
+        }
+    }
+}

--- a/Jarilo.Tests/HelpTests/EnumValues.cs
+++ b/Jarilo.Tests/HelpTests/EnumValues.cs
@@ -5,7 +5,7 @@ using System.Text;
 namespace Jarilo.Tests.HelpTests.Enum
 {
     static class EnumInfo
-	{
+    {
         internal const string Value1txt = "value-1";
         internal const string Value1Description = "Enum value 1.";
         internal const string Value2txt = "value-2";
@@ -21,8 +21,8 @@ namespace Jarilo.Tests.HelpTests.Enum
 
         [Value(EnumInfo.Value2txt, "")]
         Value2,
-		
-		[Value(EnumInfo.Value3txt, null)]
-		Value3
+
+        [Value(EnumInfo.Value3txt, null)]
+        Value3
     }
 }

--- a/Jarilo.Tests/HelpTests/EnumValues.cs
+++ b/Jarilo.Tests/HelpTests/EnumValues.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Jarilo.Tests.HelpTests.Enum
+{
+    static class EnumInfo
+	{
+        internal const string Value1txt = "value-1";
+        internal const string Value1Description = "Enum value 1.";
+        internal const string Value2txt = "value-2";
+        internal const string Value3txt = "value-3";
+    }
+
+    enum EnumValues
+    {
+        None,
+
+        [Value(EnumInfo.Value1txt, EnumInfo.Value1Description)]
+        Value1,
+
+        [Value(EnumInfo.Value2txt, "")]
+        Value2,
+		
+		[Value(EnumInfo.Value3txt, null)]
+		Value3
+    }
+}

--- a/Jarilo.Tests/HelpTests/Options.cs
+++ b/Jarilo.Tests/HelpTests/Options.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Jarilo.Tests.HelpTests.Enum
+{
+    class Options
+    {
+        [Option("--enum", "Enum option.")]
+        public EnumValues Enum { get; set; }
+    }
+}

--- a/Jarilo.Tests/HelpTests/Tests.cs
+++ b/Jarilo.Tests/HelpTests/Tests.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Jarilo.Tests.HelpTests.Enum
+{
+    public class Tests
+    {
+        [Fact]
+        public async Task ExpectedOutput()
+        {
+            var args = Command.Name + "--help";
+            await AppTest.Run(args, output =>
+            {
+                output.AssertText(output.Length-1, EnumInfo.Value3txt);
+                output.AssertText(output.Length-2, EnumInfo.Value2txt + " - ");
+                output.AssertText(output.Length-3, EnumInfo.Value1txt + " - " + EnumInfo.Value1Description);
+            });
+        }
+
+    }
+}

--- a/Jarilo/Help/HelpDocs.cs
+++ b/Jarilo/Help/HelpDocs.cs
@@ -100,7 +100,11 @@ namespace Jarilo.Help
             var values = $"\n    Possible values:";
             foreach (var value in metadata)
             {
-                values += $"\n      {value.Name} - {value.Description}";
+                values += $"\n      {value.Name}";
+                if(!(value.Description is null))
+                {
+                    values += $" - {value.Description}";
+                }
             }
             return values;
         }


### PR DESCRIPTION
[Value("name", null)] will show up in help as "name" instead of "name - ".